### PR TITLE
Use traditional for loop for legacy browsers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ export function getParams(pageURL) {
     queryString.split('&') : '';
   const params = {};
 
-  for (const rawParam of rawParams) {
+  for (let i = 0; i < rawParams.length; i++) {
+    const rawParam = rawParams[i];
     const param = rawParam.split('=');
     let paramName = param[0];
     const paramValue = param[1];


### PR DESCRIPTION
Using `for...of` is breaking PhantomJS without a poly-fill since it converts to a `Symbol` object in babel.

Can't use `forEach` either because that requires a poly-fill too for PhantomJS. :/
